### PR TITLE
cli: initialize debugdir and sourcedir variables

### DIFF
--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -235,6 +235,7 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, vcs=None, disturl=N
         os.mkdir(maindir)
 
     workdirectories = [ maindir ]
+    debugdir = sourcedir = None
     if "source" in yml:
         if yml['source'] == 'split':
             sourcedir = outdir + '/' + product_base_dir + '-Source'


### PR DESCRIPTION
Otherwise we might call link_rpms_to_tree without those variables around if "source" and "debug" are dropped.