### PR TITLE
Support for product type extension

### DIFF
--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -736,7 +736,8 @@ def run_createrepo(rpmdir, yml, content=[], repos=[]):
     if 'product-type' in yml:
       if yml['product-type'] == 'base':
         product_type = '/o'
-      elif yml['product-type'] == 'module':
+      elif yml['product-type'] in ['module', 'extension']:
+        # TODO: Validate that modules and extensions share the same CPE prefix.
         product_type = '/a'
       else:
         die('Undefined product-type')

--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -737,7 +737,6 @@ def run_createrepo(rpmdir, yml, content=[], repos=[]):
       if yml['product-type'] == 'base':
         product_type = '/o'
       elif yml['product-type'] in ['module', 'extension']:
-        # TODO: Validate that modules and extensions share the same CPE prefix.
         product_type = '/a'
       else:
         die('Undefined product-type')


### PR DESCRIPTION
`product-type` is only used to generate the CPE, and we already have `product-type` extension in previously released products.
