### PR TITLE
abort_on_empty_updateinfo build option

### DIFF
--- a/docs/build_description.adoc
+++ b/docs/build_description.adoc
@@ -168,6 +168,13 @@ conflicts can happen.
 
 Add slsa provenance files for each rpm if available
 
+===== abort_on_empty_updateinfo
+
+Existing updateinfo.xml are scanned by default and reduced to
+the available package binaries. In case none are found the
+update is skipped. Enableing this option leads to a build failure
+instead.
+
 ==== installcheck
 
 Runs a repository closure test for each architecture. This will

--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -665,8 +665,8 @@ def create_updateinfo_xml(rpmdir, yml, pool, flavor, debugdir, sourcedir):
             if 'set_updateinfo_from' in yml:
                 update.set('from', yml['set_updateinfo_from'])
 
+            id_node = update.find('id')
             if 'set_updateinfo_id_prefix' in yml:
-                id_node = update.find('id')
                 # avoid double application of same prefix
                 id_text = re.sub(r'^'+yml['set_updateinfo_id_prefix'], '', id_node.text)
                 id_node.text = yml['set_updateinfo_id_prefix'] + id_text
@@ -727,6 +727,8 @@ def create_updateinfo_xml(rpmdir, yml, pool, flavor, debugdir, sourcedir):
                 parent.remove(pkgentry)
 
             if not needed:
+                if 'abort_on_empty_updateinfo' in yml['build_options']:
+                    die(f'Stumbled over an updateinfo.xml where no rpm is used: {id_node.text}')
                 continue
 
             if not uitemp:


### PR DESCRIPTION
Existing updateinfo.xml are scanned by default and reduced to the available package binaries. In case none are found the update is skipped. Enableing this option leads to a build failure instead.