### PR TITLE
Fix subdir value is used before initialization

### DIFF
--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -366,6 +366,7 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, vcs=None, disturl=N
        for arch in yml['architectures']:
            note(f"Run installcheck for {arch}")
            args = ['installcheck', arch, '--withsrc']
+           subdir = ""
            if 'repodata' in yml:
                subdir = f"/{arch}"
            if not os.path.exists(maindir + subdir):


### PR DESCRIPTION
Initialing subdir value before be used at `os.path.exists()`, otherwise it got UnboundLocalError when `repodata` isn't defined in yml.