### PR TITLE
 cli: allow disabling package inclusion when using base images

### DIFF
--- a/docs/build_description.adoc
+++ b/docs/build_description.adoc
@@ -202,6 +202,14 @@ but building on a former released code base.
 Build a pure update repository. Skipping all matching rpms
 which are not referenced via an updateinfo.
 
+===== base_skip_packages
+
+Controls whether packages should be copied in the `/install` directory
+when using base iso images.
+
+Enabling this would result in a simply repacked base image, without
+any package copied there.
+
 ==== iso
 
 ===== publisher

--- a/examples/ftp.productcompose
+++ b/examples/ftp.productcompose
@@ -37,6 +37,7 @@ build_options:
 # - add_slsa_provenance
 # - skip_updateinfos
 # - updateinfo_packages_only
+# - base_skip_packages
 
 #installcheck:
 # - ignore_errors

--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -169,7 +169,7 @@ def parse_yaml(filename, flavor):
         # overwrite global values from flavor overwrites
         for tag in ['architectures', 'name', 'summary', 'version',
                     'product-type', 'product_directory_name',
-                    'source', 'debug']:
+                    'build_options', 'source', 'debug']:
             if tag in f:
                 yml[tag] = f[tag]
         if 'iso' in f:

--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -325,7 +325,8 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, vcs=None, disturl=N
             if sourcedir and sourcedir == workdir:
                 continue
             for arch in yml['architectures']:
-                repodatadirectories.append(workdir + f"/{arch}")
+                if os.path.exists(workdir + f"/{arch}"):
+                    repodatadirectories.append(workdir + f"/{arch}")
 
     note("Write report file")
     write_report_file(maindir, maindir + '.report')

--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -470,8 +470,9 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, vcs=None, disturl=N
         # create new iso
         tempdir = f"{outdir}/mksusecd"
         os.mkdir(tempdir)
-        args = ['cp', '-al', workdirectories[0], f"{tempdir}/install"]
-        run_helper(args, failmsg="Adding tree to agama image")
+        if not 'base_skip_packages' in yml['build_options']:
+            args = ['cp', '-al', workdirectories[0], f"{tempdir}/install"]
+            run_helper(args, failmsg="Adding tree to agama image")
         args = ['mksusecd', agamaiso, tempdir, '--create', workdirectories[0] + '.install.iso']
         if verbose_level > 0:
             print("Calling: ", args)


### PR DESCRIPTION
This PR adds the new build_option base_skip_packages that can be
used in conjunction with base images.
Controls whether packages should be copied in the `/install` directory
when repacking the image.

While it sounds counterproductive, in some specific cases it can
be useful. For SLES, it can be used to ship the Online installer
alongside the rest of the product-composer artifacts, and as a
bonus, it can also share the build number with them.

in addition, `build_options` can now be overriden by flavours.