### PR TITLE
Various bugfixes

### DIFF
--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -1071,11 +1071,11 @@ def link_file_into_dir(source, directory, name=None):
             os.link(source, outname)
 
 
-def link_entry_into_dir(entry, directory, add_slsa=False, positivelist=None):
+def link_entry_into_dir(entry, directory, add_slsa=False, positivelist={}):
     canonfilename = entry.canonfilename
     outname = directory + '/' + entry.arch + '/' + canonfilename
     if not os.path.exists(outname):
-        if not positivelist is None:
+        if positivelist:
             targetname = entry.arch + '/' + canonfilename
             if not targetname in positivelist:
                 print("No update for " + targetname)

--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -319,7 +319,7 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, vcs=None, disturl=N
         run_createrepo(sourcedir, yml, content=["source"], repos=repos)
 
     repodatadirectories = []
-    if 'repodata' in yml and yml['repodata'] != 'all':
+    if yml.get('repodata', 'all') == 'all':
         repodatadirectories = deepcopy(workdirectories)
     if 'repodata' in yml:
         for workdir in workdirectories:


### PR DESCRIPTION
First commit makes the positivelist check less strict - since we might pass an empty `referenced_update_rpms` dictionary, checking against None would still make link_entry_into_dir check against it, which might result in an empty image.

Second commit always adds the main directory in `repodatadirectories` by default even if repodata is not defined. Otherwise some stuff like repo signing is skipped.
I've also inverted the check, as (if I understood correctly), when using `repodata: all` we want the primary `/repodata` alongside the split ones, so we should add it to repodatadirectories too.

But please correct me if I understood it wrong :smile: 