### PR TITLE
Add support for blacklisted updates

### DIFF
--- a/src/productcomposer/cli.py
+++ b/src/productcomposer/cli.py
@@ -137,6 +137,19 @@ def build(args):
     note(f"scanning: {reposdir}")
     pool.scan(reposdir)
 
+    # clean up black listed packages
+    for u in sorted(pool.lookup_all_updateinfos()):
+        for update in u.root.findall('update'):
+            if not update.find('blocked_in_product'):
+                 continue
+
+            parent = update.findall('pkglist')[0].findall('collection')[0]
+            for pkgentry in parent.findall('package'):
+                name = pkgentry.get('name')
+                epoch = pkgentry.get('epoch')
+                version = pkgentry.get('version')
+                pool.remove_rpms(None, name, '=', epoch, version)
+
     if args.clean and os.path.exists(args.out):
         shutil.rmtree(args.out)
 

--- a/src/productcomposer/core/Pool.py
+++ b/src/productcomposer/core/Pool.py
@@ -57,6 +57,11 @@ class Pool:
     def lookup_all_updateinfos(self):
         return self.updateinfos.values()
 
+    def remove_rpms(self, arch, name, epoch=None, version=None, release=None):
+        if name not in self.rpms:
+            return
+        self.rpms[name] = [rpm for rpm in self.rpms[name] if not rpm.matches(arch, name, op, epoch, version, release)]
+
     def names(self, arch=None):
         if arch is None:
             return set(self.rpms.keys())


### PR DESCRIPTION
Remove all binaries from the pool if they are listed in an updateinfo with the "blocked_in_product" marker.

The updateinfo.xml itself will get skipped as well as no binary is matching any rpm as consequence.

Awaits decision if this is needed at all in OBS-386