### PR TITLE
Test with python 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,27 +12,19 @@ jobs:
   unit:
     name: "basic"
     runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - 'registry.opensuse.org/opensuse/tumbleweed'
-
-    container:
-      image: ${{ matrix.container }}
+    container: 'registry.suse.com/bci/python:3.11'
 
     steps:
       - name: 'Install packages'
         run: |
-            zypper -n modifyrepo --disable repo-openh264 || :
-            zypper -n --gpg-auto-import-keys refresh
-            zypper -n install python3 python3-pip python3-pydantic python3-pytest python3-rpm python3-setuptools python3-solv python3-PyYAML python3-schema
+            zypper -n install python311-pydantic python311-pytest python311-setuptools python311-rpm python311-PyYAML
 
       - uses: actions/checkout@v4
 
       - name: 'Run basic example verification'
         run: |
-          pip3 config set global.break-system-packages 1
-          pip3 install --no-dependencies -e .
+          python3 -m venv venv --system-site-packages
+          source venv/bin/activate
+          pip install --no-dependencies -e .
           productcomposer verify examples/ftp.productcompose
 #          pytest tests


### PR DESCRIPTION
The productcomposer is defined to work with python 3.11, so we should test with that rather than 3.13.