### PR TITLE
commands: build: ensure supportstatus_override is passed to parse_supportstatus()

### DIFF
--- a/src/productcomposer/commands/build.py
+++ b/src/productcomposer/commands/build.py
@@ -69,7 +69,7 @@ class BuildCommand:
 
         supportstatus_fn = os.path.join(directory, 'supportstatus.txt')
         if os.path.isfile(supportstatus_fn):
-            parse_supportstatus(supportstatus_fn)
+            parse_supportstatus(supportstatus_fn, supportstatus_override)
 
         if args.euladir and os.path.isdir(args.euladir):
             parse_eulas(args.euladir, eulas)


### PR DESCRIPTION
The function signature changed after the recent rework.

Fixes:

```
[   77s] Configuration is valid for flavor: sles_x86_64
[   77s] Traceback (most recent call last):
[   77s]   File "/usr/bin/product-composer", line 8, in <module>
[   77s]     sys.exit(main())
[   77s]              ~~~~^^
[   77s]   File "/usr/lib/python3.13/site-packages/productcomposer/cli.py", line 24, in main
[   77s]     dispatch(args)
[   77s]     ~~~~~~~~^^^^^^
[   77s]   File "/usr/lib/python3.13/site-packages/productcomposer/dispatcher.py", line 8, in dispatch
[   77s]     cmd_instance.run(args)
[   77s]     ~~~~~~~~~~~~~~~~^^^^^^
[   77s]   File "/usr/lib/python3.13/site-packages/productcomposer/commands/build.py", line 24, in run
[   77s]     result = self.build(args)
[   77s]   File "/usr/lib/python3.13/site-packages/productcomposer/commands/build.py", line 72, in build
[   77s]     parse_supportstatus(supportstatus_fn)
[   77s]     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
[   77s] TypeError: parse_supportstatus() missing 1 required positional argument: 'supportstatus_override'
```