### PR TITLE
Allow disabling Joliet extension, and always disable it on Source and Debug medias

### DIFF
--- a/src/productcomposer/createartifacts/createiso.py
+++ b/src/productcomposer/createartifacts/createiso.py
@@ -6,7 +6,9 @@ from ..utils.cryptoutils import create_sha256_for
 def create_iso(outdir, isoconf, workdir, application_id):
     verbose = True if verbose_level > 0 else False
     args = ['/usr/bin/mkisofs', '-quiet', '-p', ISO_PREPARER]
-    args += ['-r', '-pad', '-f', '-J', '-joliet-long']
+    args += ['-r', '-pad', '-f']
+    if isoconf['joliet']:
+        args += ['-J', '-joliet-long']
     if isoconf['publisher']:
         args += ['-publisher', isoconf['publisher']]
     if isoconf['volume_id']:

--- a/src/productcomposer/createartifacts/createtree.py
+++ b/src/productcomposer/createartifacts/createtree.py
@@ -214,7 +214,12 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, tree_report, suppor
                 note(f"Export main tree into agama iso file for {agama_arch}")
                 create_agama_iso(outdir, yml['iso'], yml['build_options'], pool, workdir, application_id, agama_arch)
             else:
-                create_iso(outdir, yml['iso'], workdir, application_id)
+                iso_config = yml['iso'].copy()
+                if workdir != maindir:
+                    # Ensure that joliet stays disabled on non-primary
+                    # media
+                    iso_config['joliet'] = False
+                create_iso(outdir, iso_config, workdir, application_id)
 
             # cleanup
             if yml['iso']['tree'] == 'drop':

--- a/src/productcomposer/parsers/yamlparser.py
+++ b/src/productcomposer/parsers/yamlparser.py
@@ -62,7 +62,7 @@ def parse_yaml(filename: str, flavor: str | None) -> Dict[str, any]:
         if f['iso']:
             if not yml['iso']:
                 yml['iso'] = compose_schema_iso().dict()
-            for tag in ('volume_id', 'publisher', 'tree', 'base'):
+            for tag in ('volume_id', 'publisher', 'tree', 'base', 'joliet'):
                 if f['iso'].get(tag):
                     yml['iso'][tag] = f['iso'][tag]
 

--- a/src/productcomposer/verifiers/composeschema.py
+++ b/src/productcomposer/verifiers/composeschema.py
@@ -11,6 +11,7 @@ class compose_schema_iso(BaseModel):
     volume_id: Optional[str] = None
     tree: Optional[str] = None
     base: Optional[str] = None
+    joliet: Optional[bool] = True
 
 
 _compose_schema_supportstatus = Literal[


### PR DESCRIPTION
Some products might not need Joliet extensions enabled, so
allow to disable them. The default is still to keep them enabled.

Joliet extensions can be disabled from the iso configuration:

```  
iso:
   joliet: false
```

Also, forcibly disable it for the non-primary medias.

debuginfo and debugsource packages increases the file name length, and
that might be too much. This might result in clashes between the actual
debug rpm and the slsa provenance file.

product-build is doing the same thing: https://github.com/openSUSE/product-builder/blob/a61474be07469838c940003c2749699b344397fc/modules/KIWICollect.pm#L785