### PR TITLE
productcomposer: add ignore_binaries_newer_than pkgset option

### DIFF
--- a/docs/build_description.adoc
+++ b/docs/build_description.adoc
@@ -118,6 +118,22 @@ However these are handled as strings. If the string starts
 with a "=", it overrides any previously set support status
 from inherited package sets.
 
+==== ignore_binaries_newer_than
+
+Whether to ignore binaries with a buildtime newer than
+specified. A valid datetime as parsed by pydantic can
+be used.
+
+    ignore_binaries_newer_than: 2025-12-30 00:00
+
+This field is optional. When not taking all the available
+binary versions, the closest package with a valid buildtime
+is used instead.
+
+Note that newly added packages (that do not have an older
+version to fallback on) will be skipped as well, and it
+might abort the build if the `ignore_missing_packages` is
+not enabled.
 
 === Details
 

--- a/src/productcomposer/core/Package.py
+++ b/src/productcomposer/core/Package.py
@@ -6,6 +6,7 @@ import re
 import rpm
 import functools
 
+from ..utils.loggerutils import note
 
 @functools.total_ordering
 class Package:
@@ -99,12 +100,15 @@ class Package:
         srcpkg.arch = match.group(4)
         return srcpkg
 
-    def matches(self, arch, name, op, epoch, version, release):
+    def matches(self, arch, name, op, epoch, version, release, ignore_binaries_newer_than=None):
         if name is not None and self.name != name:
             return False
         if arch is not None and self.arch != arch:
             if arch in ('src', 'nosrc') or self.arch != 'noarch':
                 return False
+        if ignore_binaries_newer_than is not None and self.buildtime > ignore_binaries_newer_than:
+            note(f"skipping package {self.name} {self.evr} due to buildtime over {ignore_binaries_newer_than}")
+            return False
         if op is None:
             return True
         # special case a missing release or epoch in the match as labelCompare

--- a/src/productcomposer/core/PkgSelect.py
+++ b/src/productcomposer/core/PkgSelect.py
@@ -7,8 +7,9 @@ import rpm
 
 
 class PkgSelect:
-    def __init__(self, spec, supportstatus=None):
+    def __init__(self, spec, supportstatus=None, ignore_binaries_newer_than=None):
         self.supportstatus = supportstatus
+        self.ignore_binaries_newer_than = ignore_binaries_newer_than
         match = re.match(r'([^><=]*)([><=]=?)(.*)', spec.replace(' ', ''))
         if match:
             self.name = match.group(1)
@@ -31,7 +32,7 @@ class PkgSelect:
             self.release = None
 
     def matchespkg(self, arch, pkg):
-        return pkg.matches(arch, self.name, self.op, self.epoch, self.version, self.release)
+        return pkg.matches(arch, self.name, self.op, self.epoch, self.version, self.release, ignore_binaries_newer_than=self.ignore_binaries_newer_than)
 
     @staticmethod
     def _sub_ops(op1, op2):
@@ -133,6 +134,7 @@ class PkgSelect:
         out.version = self.version
         out.release = self.release
         out.supportstatus = self.supportstatus
+        out.ignore_binaries_newer_than = self.ignore_binaries_newer_than
         return out
 
     def __str__(self):
@@ -147,8 +149,8 @@ class PkgSelect:
 
     def __hash__(self):
         if self.op:
-            return hash((self.name, self.op, self.epoch, self.version, self.release))
-        return hash(self.name)
+            return hash((self.name, self.op, self.epoch, self.version, self.release, self.ignore_binaries_newer_than))
+        return hash((self.name, self.ignore_binaries_newer_than))
 
     def __eq__(self, other):
         if self.name != other.name:

--- a/src/productcomposer/core/PkgSet.py
+++ b/src/productcomposer/core/PkgSet.py
@@ -12,6 +12,7 @@ class PkgSet:
         self.byname = None
         self.supportstatus = None
         self.override_supportstatus = False
+        self.ignore_binaries_newer_than = None
 
     def _create_byname(self):
         byname = {}
@@ -29,7 +30,7 @@ class PkgSet:
 
     def add_specs(self, specs):
         for spec in specs:
-            sel = PkgSelect(spec, supportstatus=self.supportstatus)
+            sel = PkgSelect(spec, supportstatus=self.supportstatus, ignore_binaries_newer_than=self.ignore_binaries_newer_than)
             self.pkgs.append(sel)
         self.byname = None
 

--- a/src/productcomposer/core/Pool.py
+++ b/src/productcomposer/core/Pool.py
@@ -46,13 +46,13 @@ class Pool:
                     pkg = self.make_rpm(fname, rpm_ts=ts)
                     self.add_rpm(pkg, os.path.join(reldirpath, filename))
 
-    def lookup_all_rpms(self, arch, name, op=None, epoch=None, version=None, release=None):
+    def lookup_all_rpms(self, arch, name, op=None, epoch=None, version=None, release=None, ignore_binaries_newer_than=None):
         if name not in self.rpms:
             return []
-        return [rpm for rpm in self.rpms[name] if rpm.matches(arch, name, op, epoch, version, release)]
+        return [rpm for rpm in self.rpms[name] if rpm.matches(arch, name, op, epoch, version, release, ignore_binaries_newer_than=ignore_binaries_newer_than)]
 
-    def lookup_rpm(self, arch, name, op=None, epoch=None, version=None, release=None):
-        return max(self.lookup_all_rpms(arch, name, op, epoch, version, release), default=None)
+    def lookup_rpm(self, arch, name, op=None, epoch=None, version=None, release=None, ignore_binaries_newer_than=None):
+        return max(self.lookup_all_rpms(arch, name, op, epoch, version, release, ignore_binaries_newer_than=ignore_binaries_newer_than), default=None)
 
     def lookup_all_updateinfos(self):
         return self.updateinfos.values()

--- a/src/productcomposer/createartifacts/createupdateinfoxml.py
+++ b/src/productcomposer/createartifacts/createupdateinfoxml.py
@@ -10,10 +10,12 @@ from ..wrappers import ModifyrepoWrapper
 from ..config import ET_ENCODING
 
 # create a fake package entry from an updateinfo package spec
-def create_updateinfo_package(pkgentry):
+def create_updateinfo_package(pkgentry, issued_date=None):
     entry = Package()
     for tag in ('name', 'epoch', 'version', 'release', 'arch'):
         setattr(entry, tag, pkgentry.get(tag))
+    if issued_date is not None:
+        setattr(entry, 'buildtime', issued_date)
     return entry
 
 # Add updateinfo.xml to metadata
@@ -51,6 +53,7 @@ def create_updateinfo_xml(rpmdir, yml, pool, flavor, debugdir, sourcedir, archsu
         for update in u.root.findall('update'):
             needed = False
             parent = update.findall('pkglist')[0].findall('collection')[0]
+            issued_date = int(update.find('issued').get("date"))
 
             # drop OBS internal patchinforef element
             for pr in update.findall('patchinforef'):
@@ -120,7 +123,7 @@ def create_updateinfo_xml(rpmdir, yml, pool, flavor, debugdir, sourcedir, archsu
 
                 # check if we should have this package
                 if name in main_pkgset_names and not archsubdir:
-                    updatepkg = create_updateinfo_package(pkgentry)
+                    updatepkg = create_updateinfo_package(pkgentry, issued_date=issued_date)
                     if main_pkgset.matchespkg(None, updatepkg):
                         warn(f"package {updatepkg} not found")
                         missing_package = True

--- a/src/productcomposer/utils/rpmutils.py
+++ b/src/productcomposer/utils/rpmutils.py
@@ -76,6 +76,8 @@ def create_package_set_cached(yml, arch, flavor, setname, pkgsetcache, pkgsets_r
         if pkgset.supportstatus.startswith('='):
             pkgset.override_supportstatus = True
             pkgset.supportstatus = pkgset.supportstatus[1:]
+    if entry['ignore_binaries_newer_than'] is not None:
+        pkgset.ignore_binaries_newer_than = entry['ignore_binaries_newer_than'].timestamp()
     if entry['packages']:
         pkgset.add_specs(entry['packages'])
     for setop in 'add', 'sub', 'intersect':
@@ -185,10 +187,10 @@ def link_rpms_to_tree(rpmdir, yml, pool, arch, flavor, tree_report, supportstatu
     empty_medium = True
     for sel in main_pkgset:
         if singlemode:
-            rpm = pool.lookup_rpm(arch, sel.name, sel.op, sel.epoch, sel.version, sel.release)
+            rpm = pool.lookup_rpm(arch, sel.name, sel.op, sel.epoch, sel.version, sel.release, ignore_binaries_newer_than=sel.ignore_binaries_newer_than)
             rpms = [rpm] if rpm else []
         else:
-            rpms = pool.lookup_all_rpms(arch, sel.name, sel.op, sel.epoch, sel.version, sel.release)
+            rpms = pool.lookup_all_rpms(arch, sel.name, sel.op, sel.epoch, sel.version, sel.release, ignore_binaries_newer_than=sel.ignore_binaries_newer_than)
 
         if not rpms:
             if referenced_update_rpms is not None:

--- a/src/productcomposer/verifiers/composeschema.py
+++ b/src/productcomposer/verifiers/composeschema.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from typing import Literal
 from typing import Optional
 
+from datetime import datetime
 
 class compose_schema_iso(BaseModel):
     publisher: Optional[str] = None
@@ -28,6 +29,7 @@ class compose_schema_packageset(BaseModel):
     sub: Optional[list[str]] = None
     intersect: Optional[list[str]] = None
     packages: Optional[list[str]] = None
+    ignore_binaries_newer_than: Optional[datetime] = None
 
 
 class compose_schema_scc_cpe(BaseModel):


### PR DESCRIPTION
It allows to ignore binaries with a buildtime newer than
specified. A valid datetime as parsed by pydantic can
be used.
    
        ignore_binaries_newer_than: 2025-12-30 00:00
    
This field is optional. When not taking all the available
binary versions, the closest package with a valid buildtime
is used instead.
    
Note that newly added packages (that do not have an older
version to fallback on) will be skipped as well, and it
might abort the build if the `ignore_missing_packages` is
not enabled.
