### PR TITLE
Support forcing supportstatus level with a leading '='

### DIFF
--- a/docs/build_description.adoc
+++ b/docs/build_description.adoc
@@ -132,7 +132,8 @@ Define support status level for the packages listed in
 packages. Valid support levels are l3, l2, unsupported.
 However these are handled as strings. If the string starts
 with a "=", it overrides any previously set support status
-from inherited package sets.
+from inherited package sets and entries from supportstatus.txt
+when writing repodata.
 
 
 === Details
@@ -455,4 +456,3 @@ still being able to identify the filtering for a specific product.
 
 The current default is to include maintenance updates under embargo. This option can
 be set to abort when an embargo date is in future.
-

--- a/src/productcomposer/core/PkgSelect.py
+++ b/src/productcomposer/core/PkgSelect.py
@@ -7,8 +7,9 @@ import rpm
 
 
 class PkgSelect:
-    def __init__(self, spec, supportstatus=None):
+    def __init__(self, spec, supportstatus=None, supportstatus_forced=False):
         self.supportstatus = supportstatus
+        self.supportstatus_forced = supportstatus_forced and supportstatus is not None
         match = re.match(r'([^><=]*)([><=]=?)(.*)', spec.replace(' ', ''))
         if match:
             self.name = match.group(1)
@@ -65,6 +66,20 @@ class PkgSelect:
     def _throw_unsupported_intersect(self, other):
         raise RuntimeError(f"unsupported intersect operation: {self}, {other}")
 
+    def _merge_supportstatus(self, other):
+        if self.supportstatus_forced:
+            return self.supportstatus, True
+        if other.supportstatus_forced:
+            return other.supportstatus, True
+        if self.supportstatus is not None:
+            return self.supportstatus, False
+        return other.supportstatus, False
+
+    def _copy_with_merged_supportstatus(self, other):
+        out = self.copy()
+        out.supportstatus, out.supportstatus_forced = self._merge_supportstatus(other)
+        return out
+
     def sub(self, other):
         if self.name != other.name:
             return self
@@ -95,15 +110,18 @@ class PkgSelect:
         if self.name != other.name:
             return None
         if other.op is None:
-            return self
+            return self._copy_with_merged_supportstatus(other)
         if self.op is None:
-            return other
+            return other._copy_with_merged_supportstatus(self)
         cmp = self._cmp_evr(other)
         if cmp == 0:
             if self.release is not None or other.release is None:
                 out = self.copy()
+                merge_other = other
             else:
                 out = other.copy()
+                merge_other = self
+            out.supportstatus, out.supportstatus_forced = out._merge_supportstatus(merge_other)
             out.op = PkgSelect._intersect_ops(self.op, other.op)
             if out.op == '':
                 if (self.release is not None and other.release is None) or (other.release is not None and self.release is None):
@@ -112,16 +130,16 @@ class PkgSelect:
             return out
         elif cmp < 0:
             if '>' in self.op and '<' not in other.op:
-                return other
+                return other._copy_with_merged_supportstatus(self)
             if '<' in other.op and '>' not in self.op:
-                return self
+                return self._copy_with_merged_supportstatus(other)
             if '<' not in other.op and '>' not in self.op:
                 return None
         elif cmp > 0:
             if '>' in other.op and '<' not in self.op:
-                return self
+                return self._copy_with_merged_supportstatus(other)
             if '<' in self.op and '>' not in other.op:
-                return other
+                return other._copy_with_merged_supportstatus(self)
             if '<' not in self.op and '>' not in other.op:
                 return None
         self._throw_unsupported_intersect(other)
@@ -133,6 +151,7 @@ class PkgSelect:
         out.version = self.version
         out.release = self.release
         out.supportstatus = self.supportstatus
+        out.supportstatus_forced = self.supportstatus_forced
         return out
 
     def __str__(self):

--- a/src/productcomposer/core/PkgSet.py
+++ b/src/productcomposer/core/PkgSet.py
@@ -27,21 +27,41 @@ class PkgSet:
             self._create_byname()
         return self.byname
 
+    @staticmethod
+    def _apply_supportstatus(sel, supportstatus, supportstatus_forced):
+        sel.supportstatus = supportstatus
+        sel.supportstatus_forced = supportstatus_forced and supportstatus is not None
+
+    def _merge_duplicate_supportstatus(self, existing, incoming):
+        if existing.supportstatus_forced:
+            return
+        if incoming.supportstatus_forced:
+            self._apply_supportstatus(existing, incoming.supportstatus, True)
+            return
+        if existing.supportstatus is None and incoming.supportstatus is not None:
+            self._apply_supportstatus(existing, incoming.supportstatus, False)
+
     def add_specs(self, specs):
         for spec in specs:
-            sel = PkgSelect(spec, supportstatus=self.supportstatus)
+            sel = PkgSelect(spec, supportstatus=self.supportstatus, supportstatus_forced=self.override_supportstatus)
             self.pkgs.append(sel)
         self.byname = None
 
     def add(self, other):
-        s1 = set(self)
+        indices = {sel: i for i, sel in enumerate(self.pkgs)}
         for sel in other.pkgs:
-            if sel not in s1:
-                if self.override_supportstatus or (self.supportstatus is not None and sel.supportstatus is None):
-                    sel = sel.copy()
-                    sel.supportstatus = self.supportstatus
-                self.pkgs.append(sel)
-                s1.add(sel)
+            idx = indices.get(sel)
+            if idx is not None:
+                # copy before mutating: the existing selector may be shared with a cached set
+                existing = self.pkgs[idx].copy()
+                self.pkgs[idx] = existing
+                self._merge_duplicate_supportstatus(existing, sel)
+                continue
+            if self.override_supportstatus or (self.supportstatus is not None and sel.supportstatus is None):
+                sel = sel.copy()
+                self._apply_supportstatus(sel, self.supportstatus, self.override_supportstatus)
+            indices[sel] = len(self.pkgs)
+            self.pkgs.append(sel)
         self.byname = None
 
     def sub(self, other):
@@ -63,17 +83,21 @@ class PkgSet:
     def intersect(self, other):
         otherbyname = other._byname()
         pkgs = []
-        s1 = set()
-        pkgs = []
+        byisel = {}
         for sel in self.pkgs:
             name = sel.name
             if name not in otherbyname:
                 continue
             for osel in otherbyname[name]:
                 isel = sel.intersect(osel)
-                if isel and isel not in s1:
+                if not isel:
+                    continue
+                existing = byisel.get(isel)
+                if existing is not None:
+                    self._merge_duplicate_supportstatus(existing, isel)
+                else:
+                    byisel[isel] = isel
                     pkgs.append(isel)
-                    s1.add(isel)
         self.pkgs = pkgs
         self.byname = None
 

--- a/src/productcomposer/createartifacts/createtree.py
+++ b/src/productcomposer/createartifacts/createtree.py
@@ -61,6 +61,7 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, tree_report, suppor
             if 'take_all_available_versions' not in yml['build_options']:
                 die("updateinfo information will be used, but take_all_available_versions is not enabled. Either use take_all_available_versions or skip_updateinfos as build_option.")
 
+    forced_supportstatus = set()
     for arch in yml['architectures']:
         note(f"Linking rpms for {arch}")
         required_cpeid = get_cpeid(yml)
@@ -68,7 +69,7 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, tree_report, suppor
             # handle the special case for legacy x86 builds where some additional i686 rpms 
             # get added, but it is still handled as a single common i586 architecture.
             required_cpeid = None
-        link_rpms_to_tree(maindir, yml, pool, arch, flavor, tree_report, supporstatus, supportstatus_override, debugdir, sourcedir, required_cpeid)
+        link_rpms_to_tree(maindir, yml, pool, arch, flavor, tree_report, supporstatus, supportstatus_override, debugdir, sourcedir, required_cpeid, forced_supportstatus)
 
     for arch in yml['architectures']:
         note(f"Unpack rpms for {arch}")
@@ -320,4 +321,3 @@ def create_tree(outdir, product_base_dir, yml, pool, flavor, tree_report, suppor
             if os.path.exists(repodatadir):
                 note(f"Removing {repodatadir}")
                 shutil.rmtree(repodatadir)
-

--- a/src/productcomposer/utils/rpmutils.py
+++ b/src/productcomposer/utils/rpmutils.py
@@ -151,7 +151,9 @@ def unpack_meta_rpms(rpmdir, yml, pool, arch, flavor, medium):
     if missing_package and 'ignore_missing_packages' not in yml['build_options']:
         die('Abort due to missing meta packages')
 
-def link_rpms_to_tree(rpmdir, yml, pool, arch, flavor, tree_report, supportstatus, supportstatus_override, debugdir=None, sourcedir=None, cpeid=None):
+def link_rpms_to_tree(rpmdir, yml, pool, arch, flavor, tree_report, supportstatus, supportstatus_override, debugdir=None, sourcedir=None, cpeid=None, forced_supportstatus=None):
+    if forced_supportstatus is None:
+        forced_supportstatus = set()
     singlemode = True
     if 'take_all_available_versions' in yml['build_options']:
         singlemode = False
@@ -210,7 +212,12 @@ def link_rpms_to_tree(rpmdir, yml, pool, arch, flavor, tree_report, supportstatu
                     continue
 
             link_entry_into_dir(tree_report, rpm, rpmdir, add_slsa=add_slsa)
-            if rpm.name in supportstatus_override:
+            if sel.supportstatus_forced:
+                supportstatus[rpm.name] = sel.supportstatus
+                forced_supportstatus.add(rpm.name)
+            elif rpm.name in forced_supportstatus:
+                pass  # forced by an earlier architecture; keep that value
+            elif rpm.name in supportstatus_override:
                 supportstatus[rpm.name] = supportstatus_override[rpm.name]
             else:
                 supportstatus[rpm.name] = sel.supportstatus
@@ -264,4 +271,3 @@ def link_rpms_to_tree(rpmdir, yml, pool, arch, flavor, tree_report, supportstatu
         warn("This medium is not providing any rpm. Only online installation is possible.")
     elif cpeid and not found_matching_cpeid and 'no_product_provides' not in yml['build_options']:
         die(f"Product release file with matching cpeid {cpeid} not found!")
-

--- a/tests/unit/core/test_supportstatus_precedence.py
+++ b/tests/unit/core/test_supportstatus_precedence.py
@@ -1,0 +1,280 @@
+from productcomposer.core.PkgSelect import PkgSelect
+from productcomposer.utils import rpmutils
+from productcomposer.utils.rpmutils import (
+    create_package_set,
+    create_package_set_cached,
+    link_rpms_to_tree,
+)
+
+
+class FakeRpm:
+    name = "test-package"
+    arch = "x86_64"
+    canonfilename = "test-package.rpm"
+    location = "/unused/test-package.rpm"
+    provides = []
+
+    def get_src_package(self):
+        return None
+
+
+class FakePool:
+    updateinfos = []
+
+    def __init__(self, rpm):
+        self.rpm = rpm
+
+    def lookup_all_updateinfos(self):
+        return []
+
+    def lookup_rpm(self, arch, name, op=None, epoch=None, version=None, release=None):
+        if arch == "x86_64" and name == self.rpm.name:
+            return self.rpm
+        return None
+
+
+def _supportstatus_in(pkgset, package):
+    for sel in pkgset:
+        if sel.name == package:
+            return sel.supportstatus, sel.supportstatus_forced
+    raise AssertionError(f"{package} not found")
+
+
+def _supportstatus_for(yml, setname, package):
+    return _supportstatus_in(create_package_set(yml, "x86_64", None, setname), package)
+
+
+def _packageset(**kwargs):
+    out = {
+        "name": "main",
+        "supportstatus": None,
+        "flavors": None,
+        "architectures": None,
+        "add": None,
+        "sub": None,
+        "intersect": None,
+        "packages": None,
+    }
+    out.update(kwargs)
+    return out
+
+
+def _link_supportstatus(yml, file_supportstatus, monkeypatch, package="test-package"):
+    supportstatus = {}
+    supportstatus_override = {package: file_supportstatus}
+    rpm = FakeRpm()
+    rpm.name = package
+    rpm.canonfilename = f"{package}.rpm"
+    rpm.location = f"/unused/{package}.rpm"
+
+    monkeypatch.setattr(rpmutils, "link_entry_into_dir", lambda *args, **kwargs: None)
+    link_rpms_to_tree(
+        "/unused",
+        yml,
+        FakePool(rpm),
+        "x86_64",
+        None,
+        {},
+        supportstatus,
+        supportstatus_override,
+    )
+
+    return supportstatus[package]
+
+
+def test_file_supportstatus_overrides_normal_yaml_supportstatus(monkeypatch):
+    yml = {
+        "build_options": [],
+        "content": ["main"],
+        "packagesets": [
+            _packageset(supportstatus="l2", packages=["test-package"]),
+        ],
+    }
+
+    assert _link_supportstatus(yml, "unsupported", monkeypatch) == "unsupported"
+
+
+def test_forced_yaml_supportstatus_overrides_file_supportstatus(monkeypatch):
+    yml = {
+        "build_options": [],
+        "content": ["main"],
+        "packagesets": [
+            _packageset(supportstatus="=unsupported", packages=["test-package"]),
+        ],
+    }
+
+    assert _link_supportstatus(yml, "l3", monkeypatch) == "unsupported"
+
+
+def test_forced_supportstatus_is_not_overwritten_by_later_non_equal_selector(
+    monkeypatch,
+):
+    yml = {
+        "build_options": [],
+        "content": ["main"],
+        "packagesets": [
+            _packageset(
+                name="forced", supportstatus="=l2", packages=["test-package >= 1"]
+            ),
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(name="main", add=["forced", "normal"]),
+        ],
+    }
+
+    assert _link_supportstatus(yml, "unsupported", monkeypatch) == "l2"
+
+
+def test_later_forced_non_equal_selector_overwrites_file_supportstatus(monkeypatch):
+    yml = {
+        "build_options": [],
+        "content": ["main"],
+        "packagesets": [
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(
+                name="forced", supportstatus="=l2", packages=["test-package >= 1"]
+            ),
+            _packageset(name="main", add=["normal", "forced"]),
+        ],
+    }
+
+    assert _link_supportstatus(yml, "unsupported", monkeypatch) == "l2"
+
+
+def test_forced_supportstatus_survives_copy():
+    sel = PkgSelect("test-package", supportstatus="l2", supportstatus_forced=True)
+
+    copied = sel.copy()
+
+    assert copied.supportstatus == "l2"
+    assert copied.supportstatus_forced is True
+
+
+def test_forced_supportstatus_is_applied_to_added_packages():
+    yml = {
+        "packagesets": [
+            _packageset(name="forced", supportstatus="=l2", packages=["test-package"]),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "forced", "test-package") == ("l2", True)
+
+
+def test_forced_supportstatus_survives_package_set_add():
+    yml = {
+        "packagesets": [
+            _packageset(name="base", supportstatus="=l2", packages=["test-package"]),
+            _packageset(name="main", add=["base"]),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "main", "test-package") == ("l2", True)
+
+
+def test_duplicate_upgrade_does_not_mutate_source_package_set():
+    yml = {
+        "packagesets": [
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(name="forced", supportstatus="=l2", packages=["test-package"]),
+            _packageset(name="main", add=["normal", "forced"]),
+            _packageset(name="reuse-normal", add=["normal"]),
+        ],
+    }
+
+    pkgsetcache = {}
+    pkgsets_rawcache = {}
+    main = create_package_set_cached(
+        yml, "x86_64", None, "main", pkgsetcache, pkgsets_rawcache
+    )
+    reuse_normal = create_package_set_cached(
+        yml, "x86_64", None, "reuse-normal", pkgsetcache, pkgsets_rawcache
+    )
+
+    assert _supportstatus_in(main, "test-package") == ("l2", True)
+    assert _supportstatus_in(reuse_normal, "test-package") == (
+        "unsupported",
+        False,
+    )
+
+
+def test_forced_duplicate_supportstatus_upgrades_existing_selector():
+    yml = {
+        "packagesets": [
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(name="forced", supportstatus="=l2", packages=["test-package"]),
+            _packageset(name="main", add=["normal", "forced"]),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "main", "test-package") == ("l2", True)
+
+
+def test_existing_forced_supportstatus_is_not_downgraded_by_normal_duplicate():
+    yml = {
+        "packagesets": [
+            _packageset(name="forced", supportstatus="=l2", packages=["test-package"]),
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(name="main", add=["forced", "normal"]),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "main", "test-package") == ("l2", True)
+
+
+def test_forced_supportstatus_survives_intersect():
+    yml = {
+        "packagesets": [
+            _packageset(name="forced", supportstatus="=l2", packages=["test-package"]),
+            _packageset(name="filter", packages=["test-package"]),
+            _packageset(name="main", add=["forced"], intersect=["filter"]),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "main", "test-package") == ("l2", True)
+
+
+def test_forced_supportstatus_survives_intersect_duplicate_collapse():
+    yml = {
+        "packagesets": [
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(
+                name="forced", supportstatus="=l2", packages=["test-package >= 1"]
+            ),
+            _packageset(name="filter", packages=["test-package >= 1"]),
+            _packageset(
+                name="main", add=["normal", "forced"], intersect=["filter"]
+            ),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "main", "test-package") == ("l2", True)
+
+
+def test_forced_supportstatus_survives_intersect_duplicate_collapse_reversed():
+    yml = {
+        "packagesets": [
+            _packageset(
+                name="forced", supportstatus="=l2", packages=["test-package >= 1"]
+            ),
+            _packageset(
+                name="normal", supportstatus="unsupported", packages=["test-package"]
+            ),
+            _packageset(name="filter", packages=["test-package >= 1"]),
+            _packageset(
+                name="main", add=["forced", "normal"], intersect=["filter"]
+            ),
+        ],
+    }
+
+    assert _supportstatus_for(yml, "main", "test-package") == ("l2", True)


### PR DESCRIPTION
A supportstatus level prefixed with `=` (e.g. `=unsupported`) now **forces** that level for the listed packages, taking precedence over supportstatus.txt

Unlike a normal supportstatus, a forced value overrides both:
- supportstatus inherited from other package sets via add/intersect
- the per-package overrides read from supportstatus.txt

This allows us to have the whole `SLE_BCI` repository marked as unsupported without stray l2 supported packages that get inherited from supportstatus.txt