### PR TITLE
build: remove tests from package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ version = {attr = "productcomposer.__version__"}
 readme = {file = ["README.rst"], content-type = "text/x-rst"}
 
 [tool.setuptools.packages.find]
-where = ["src", "tests"]
+where = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = "src"


### PR DESCRIPTION
Remove 'tests' from setuptools package discovery to prevent `test` subdirectories being installed into the top level directory.